### PR TITLE
Make more compatible

### DIFF
--- a/GeoidHeights.Tests/XUnitTestProject1/GeoidHeights.Tests.csproj
+++ b/GeoidHeights.Tests/XUnitTestProject1/GeoidHeights.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <AssemblyName>GeoidHeight.Tests</AssemblyName>
+
+    <RootNamespace>GeoidHeight.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GeoidHeights\GeoidHeights.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GeoidHeights.Tests/XUnitTestProject1/UnitTest1.cs
+++ b/GeoidHeights.Tests/XUnitTestProject1/UnitTest1.cs
@@ -1,0 +1,25 @@
+using GeoidHeightsDotNet;
+using System;
+using Xunit;
+using Debug = System.Diagnostics.Debug;
+
+namespace GeoidHeight.Tests
+{
+    public class TestGroup
+    {
+        [Theory]
+        [InlineData(38.6281550, 269.7791550, -31.629207585055408)]
+        [InlineData(-14.621217, 305.021114, -2.966004569710332)]
+        [InlineData(46.874319, 102.448729, -43.572016370945285)]
+        [InlineData(-23.617446, 133.874712, 15.867758550982687)]
+        [InlineData(38.625473, 359.999500, 50.06503036214729)]
+        [InlineData(-00.466744, 0.002300, 17.329539958821204)]
+        public void ReturnsExpectedUndulationValues(double lat, double lon, double expected)
+        {
+            double h = GeoidHeights.undulation(lat, lon);
+            Console.WriteLine(h);
+            Debug.WriteLine(h);
+            Assert.Equal(expected, h);
+        }
+    }
+}

--- a/GeoidHeights/GeoidHeights.csproj
+++ b/GeoidHeights/GeoidHeights.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <PackageId>GeoidHeightsDotNet</PackageId>
     <PackageVersion>1.0.2</PackageVersion>
     <Authors>Matej Frančeškin, Janus Weil</Authors>

--- a/GeoidHeightsDotNet.sln
+++ b/GeoidHeightsDotNet.sln
@@ -1,9 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeoidHeightsDotNetProg", "GeoidHeightsDotNetProg.csproj", "{206FF110-ECB1-4F98-A86E-CF95B736F765}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30523.141
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeoidHeightsDotNetProg", "GeoidHeightsDotNetProg.csproj", "{206FF110-ECB1-4F98-A86E-CF95B736F765}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeoidHeights", "GeoidHeights\GeoidHeights.csproj", "{FD7AC5FF-80F0-4E9F-A482-DF6065F8AD15}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeoidHeights", "GeoidHeights\GeoidHeights.csproj", "{FD7AC5FF-80F0-4E9F-A482-DF6065F8AD15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeoidHeights.Tests", "GeoidHeights.Tests\XUnitTestProject1\GeoidHeights.Tests.csproj", "{B1A21468-C2BA-4DC9-8D0D-CCE074B7761C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,5 +22,15 @@ Global
 		{FD7AC5FF-80F0-4E9F-A482-DF6065F8AD15}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD7AC5FF-80F0-4E9F-A482-DF6065F8AD15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD7AC5FF-80F0-4E9F-A482-DF6065F8AD15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1A21468-C2BA-4DC9-8D0D-CCE074B7761C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1A21468-C2BA-4DC9-8D0D-CCE074B7761C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1A21468-C2BA-4DC9-8D0D-CCE074B7761C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1A21468-C2BA-4DC9-8D0D-CCE074B7761C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3473F622-623E-4008-8448-26D5FED51237}
 	EndGlobalSection
 EndGlobal

--- a/GeoidHeightsDotNetProg.csproj
+++ b/GeoidHeightsDotNetProg.csproj
@@ -12,7 +12,6 @@
     <Compile Remove="GeoidHeights\Coef.cs" />
     <Compile Remove="GeoidHeights\GeoidHeights.cs" />
     <Compile Remove="GeoidHeights\Properties\AssemblyInfo.cs" />
-    <Compile Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.AssemblyInfo.cs" />
     <Compile Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -30,13 +29,6 @@
     <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.AssemblyInfoInputs.cache" />
     <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.csproj.FileListAbsolute.txt" />
     <None Remove="GeoidHeights\obj\Debug\GeoidHeights.csprojAssemblyReference.cache" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.pdb" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.csproj.CoreCompileInputs.cache" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.assets.cache" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.dll" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.AssemblyInfoInputs.cache" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.csprojAssemblyReference.cache" />
-    <None Remove="GeoidHeights\obj\Debug\netstandard2.1\GeoidHeights.csproj.FileListAbsolute.txt" />
     <None Remove="GeoidHeights\bin\Release\netstandard2.1\GeoidHeights.pdb" />
     <None Remove="GeoidHeights\bin\Release\netstandard2.1\GeoidHeights.dll" />
     <None Remove="GeoidHeights\bin\Release\netstandard2.1\GeoidHeights.deps.json" />

--- a/GeoidHeightsDotNetProg.csproj
+++ b/GeoidHeightsDotNetProg.csproj
@@ -9,33 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="GeoidHeights\Coef.cs" />
-    <Compile Remove="GeoidHeights\GeoidHeights.cs" />
-    <Compile Remove="GeoidHeights\Properties\AssemblyInfo.cs" />
-    <Compile Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.AssemblyInfo.cs" />
+    <Compile Remove="GeoidHeights.Tests\**" />
+    <Compile Remove="GeoidHeights\**" />
+    <EmbeddedResource Remove="GeoidHeights.Tests\**" />
+    <EmbeddedResource Remove="GeoidHeights\**" />
+    <None Remove="GeoidHeights.Tests\**" />
+    <None Remove="GeoidHeights\**" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="GeoidHeights\" />
-    <None Remove="GeoidHeights\.DS_Store" />
-    <None Remove="GeoidHeights\obj\GeoidHeights.csproj.nuget.g.targets" />
-    <None Remove="GeoidHeights\obj\GeoidHeights.csproj.nuget.cache" />
-    <None Remove="GeoidHeights\obj\GeoidHeights.csproj.nuget.g.props" />
-    <None Remove="GeoidHeights\obj\GeoidHeights.csproj.nuget.dgspec.json" />
-    <None Remove="GeoidHeights\obj\project.assets.json" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.pdb" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.csproj.CoreCompileInputs.cache" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.assets.cache" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.dll" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.AssemblyInfoInputs.cache" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.csproj.FileListAbsolute.txt" />
-    <None Remove="GeoidHeights\obj\Debug\GeoidHeights.csprojAssemblyReference.cache" />
-    <None Remove="GeoidHeights\bin\Release\netstandard2.1\GeoidHeights.pdb" />
-    <None Remove="GeoidHeights\bin\Release\netstandard2.1\GeoidHeights.dll" />
-    <None Remove="GeoidHeights\bin\Release\netstandard2.1\GeoidHeights.deps.json" />
-    <None Remove="GeoidHeights\bin\Debug\netstandard2.1\GeoidHeights.pdb" />
-    <None Remove="GeoidHeights\bin\Debug\netstandard2.1\GeoidHeights.dll" />
-    <None Remove="GeoidHeights\bin\Debug\netstandard2.1\GeoidHeights.deps.json" />
-    <None Remove="GeoidHeights\obj\Release\netstandard2.1\GeoidHeights.csprojAssemblyReference.cache" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="GeoidHeights\GeoidHeights.csproj" />


### PR DESCRIPTION
This sets the .NET Stnd version at the lowest required by the library code to increase re-usability.