### PR TITLE
CI: add GitHub Actions config

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,10 +23,12 @@ jobs:
       run: dotnet restore GeoidHeightsDotNet.sln
     - name: Build (debug)
       run: dotnet build --no-restore -p:PackageVersion=$(git describe --tags) GeoidHeightsDotNet.sln
-    - name: Test
+    - name: Test (debug)
       run: dotnet test --no-build --verbosity normal GeoidHeightsDotNet.sln
     - name: Build (release)
       run: dotnet build --no-restore --configuration Release -p:PackageVersion=$(git describe --tags) GeoidHeightsDotNet.sln
+    - name: Test (release)
+      run: dotnet test --no-build --verbosity normal --configuration Release GeoidHeightsDotNet.sln
     - name: Upload nupkg
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Restore dependencies
+      run: dotnet restore GeoidHeightsDotNet.sln
+    - name: Build (debug)
+      run: dotnet build --no-restore -p:PackageVersion=$(git describe --tags) GeoidHeightsDotNet.sln
+    - name: Test
+      run: dotnet test --no-build --verbosity normal GeoidHeightsDotNet.sln
+    - name: Build (release)
+      run: dotnet build --no-restore --configuration Release -p:PackageVersion=$(git describe --tags) GeoidHeightsDotNet.sln
+    - name: Upload nupkg
+      uses: actions/upload-artifact@v2
+      with:
+        name: nupkg
+        path: GeoidHeights/bin/Release/*.nupkg


### PR DESCRIPTION
- loosely based on: https://github.com/actions/starter-workflows/blob/main/ci/dotnet.yml
- builds the project, runs the tests and uploads the nupkg artifact
- the package version is based on 'git describe'
- the build is triggered by pushes and pull requests to the master branch (or manually)
- see issue #8